### PR TITLE
Fix trimming and alternative filepath expansion

### DIFF
--- a/lua/aoc/config.lua
+++ b/lua/aoc/config.lua
@@ -19,7 +19,8 @@ M.init = function(args)
 
    M.options.session_filepath = vim.fn.expand(M.options.session_filepath)
    if M.options.puzzle_input.alternative_filepath then
-      M.options.alternative_filepath = vim.fn.expand(M.options.alternative_filepath)
+      M.options.puzzle_input.alternative_filepath =
+         vim.fn.expand(M.options.puzzle_input.alternative_filepath)
    end
 end
 

--- a/lua/aoc/utils.lua
+++ b/lua/aoc/utils.lua
@@ -5,8 +5,8 @@ local M = {}
 ---@param s string
 ---@return string
 M.trim = function(s)
-   s, _ = string.gsub(s, "%s+", "")
-   return s
+   local result, _ = string.gsub(s, "^%s*(.-)%s*$", "%1")
+   return result
 end
 
 --- Create a simple popup message, positioned in the bottom right corner of the buffer


### PR DESCRIPTION
## Summary
- ensure `trim` only removes surrounding whitespace
- correctly expand `puzzle_input.alternative_filepath` on setup

## Testing
- `stylua lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842730d68a48328b434d70de633d51f